### PR TITLE
0.3 Dev

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ $ composer require ricardofiorani/php-video-url-parser
 ## Requirements
 
 * PHP 5.3
-* cURL
+* cURL (Or at least file_get_contents() enabled if you want to use it with Vimeo, otherwise it's not required)
 
 ## Basic Usage
 
 ```php
 <?php
-use RicardoFiorani\Detector\VideoServiceDetector;
+use RicardoFiorani\Matcher\VideoServiceMatcher;
 
 require __DIR__ . '/vendor/autoload.php';
 
-$vsd = new VideoServiceDetector();
+$vsd = new VideoServiceMatcher();
 
 //Detects which service the url belongs to and returns the service's implementation
 //of RicardoFiorani\Adapter\VideoAdapterInterface
@@ -114,11 +114,11 @@ class MyOwnRendererFactory implements RendererFactoryInterface
 
 ```php
 <?php
-use RicardoFiorani\Detector\VideoServiceDetector;
+use RicardoFiorani\Matcher\VideoServiceMatcher;
 
 require __DIR__ . '/vendor/autoload.php';
 
-$vsd = new VideoServiceDetector();
+$vsd = new VideoServiceMatcher();
 
 //This is where the magic is done
 $vsd->getServiceContainer()->setRenderer('MyOwnRenderer', 'MyVendor\\MyRenderer\\Factory\\MyOwnRendererFactory');

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "name": "ricardofiorani/php-video-url-parser",
     "description": "PHP Video URL Parser is a simple video url parser.",
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "guzzlehttp/guzzle": ">=6"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,7 @@
     "name": "ricardofiorani/php-video-url-parser",
     "description": "PHP Video URL Parser is a simple video url parser.",
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
-        "guzzlehttp/guzzle": ">=6"
+        "phpunit/phpunit": "^4.8"
     },
     "license": "MIT",
     "authors": [

--- a/config/config.php
+++ b/config/config.php
@@ -10,7 +10,8 @@ return array(
     'services' => array(
         'Vimeo' => array(
             'patterns' => array(
-                '#(https?://vimeo.com)/([0-9]+)#i'
+                '#(https?://vimeo.com)/([0-9]+)#i',
+                '#(https?://vimeo.com)/channels/staffpicks/([0-9]+)#i',
             ),
             'factory' => '\\RicardoFiorani\\Adapter\\Vimeo\\Factory\\VimeoServiceAdapterFactory',
         ),

--- a/example/RegisteringANewService.md
+++ b/example/RegisteringANewService.md
@@ -159,11 +159,11 @@ class DailymotionServiceAdapterFactory implements \RicardoFiorani\Adapter\Factor
 
 ```php
 <?php
-use RicardoFiorani\Detector\VideoServiceDetector;
+use RicardoFiorani\Matcher\VideoServiceMatcher;
 
 require __DIR__ . '/vendor/autoload.php';
 
-$vsd = new VideoServiceDetector();
+$vsd = new VideoServiceMatcher();
 //The Service Name
 $serviceName = 'Dailymotion';
 

--- a/src/Adapter/Dailymotion/DailymotionServiceAdapter.php
+++ b/src/Adapter/Dailymotion/DailymotionServiceAdapter.php
@@ -9,6 +9,7 @@
 namespace RicardoFiorani\Adapter\Dailymotion;
 
 use RicardoFiorani\Adapter\AbstractServiceAdapter;
+use RicardoFiorani\Exception\InvalidThumbnailSizeException;
 use RicardoFiorani\Renderer\EmbedRendererInterface;
 
 class DailymotionServiceAdapter extends AbstractServiceAdapter
@@ -62,11 +63,12 @@ class DailymotionServiceAdapter extends AbstractServiceAdapter
     /**
      * @param string $size
      * @return string
+     * @throws InvalidThumbnailSizeException
      */
     public function getThumbnail($size)
     {
         if (false == in_array($size, $this->getThumbNailSizes())) {
-            throw new \RicardoFiorani\Exception\InvalidThumbnailSizeException;
+            throw new InvalidThumbnailSizeException;
         }
 
         return 'http://www.dailymotion.com/' . $size . '/video/' . $this->videoId;

--- a/src/Adapter/Facebook/FacebookServiceAdapter.php
+++ b/src/Adapter/Facebook/FacebookServiceAdapter.php
@@ -30,7 +30,6 @@ class FacebookServiceAdapter extends AbstractServiceAdapter
         $match = array();
         preg_match($pattern, $url, $match);
         $this->setVideoId($match[1]);
-
         return parent::__construct($url, $pattern, $renderer);
     }
 

--- a/src/Adapter/VideoAdapterInterface.php
+++ b/src/Adapter/VideoAdapterInterface.php
@@ -8,9 +8,6 @@
 
 namespace RicardoFiorani\Adapter;
 
-
-use RicardoFiorani\Renderer\EmbedRendererInterface;
-
 interface VideoAdapterInterface
 {
 
@@ -63,7 +60,7 @@ interface VideoAdapterInterface
     public function getLargeThumbnail();
 
     /**
-     * Returns the largest thumnbnaail's url
+     * Returns the largest thumnbnail's url
      * @return string
      */
     public function getLargestThumbnail();

--- a/src/Adapter/Vimeo/Factory/VimeoServiceAdapterFactory.php
+++ b/src/Adapter/Vimeo/Factory/VimeoServiceAdapterFactory.php
@@ -18,13 +18,13 @@ class VimeoServiceAdapterFactory implements CallableServiceAdapterFactoryInterfa
     /**
      * @param string $url
      * @param string $pattern
-     * @param EmbedRendererInterface $rendererInterface
+     * @param EmbedRendererInterface $renderer
      * @return VimeoServiceAdapter
+     * @internal param EmbedRendererInterface $rendererInterface
      */
     public function __invoke($url, $pattern, EmbedRendererInterface $renderer)
     {
         $adapter = new VimeoServiceAdapter($url, $pattern, $renderer);
-
         return $adapter;
     }
 }

--- a/src/Adapter/Vimeo/VimeoServiceAdapter.php
+++ b/src/Adapter/Vimeo/VimeoServiceAdapter.php
@@ -214,9 +214,6 @@ class VimeoServiceAdapter extends AbstractServiceAdapter
         $match = array();
         preg_match($pattern, $url, $match);
         $videoId = $match[2];
-        if (empty($videoId)) {
-            $videoId = $match[1];
-        }
 
         return $videoId;
     }
@@ -234,6 +231,7 @@ class VimeoServiceAdapter extends AbstractServiceAdapter
             throw new ServiceApiNotAvailable('Vimeo Service Adapter could not reach Vimeo API Service. Check if your server has file_get_contents() function available.');
         }
         $hash = unserialize($contents);
+
         return reset($hash);
     }
 }

--- a/src/Adapter/Youtube/YoutubeServiceAdapter.php
+++ b/src/Adapter/Youtube/YoutubeServiceAdapter.php
@@ -15,13 +15,11 @@ use RicardoFiorani\Renderer\EmbedRendererInterface;
 
 class YoutubeServiceAdapter extends AbstractServiceAdapter
 {
-
     const THUMBNAIL_DEFAULT = 'default';
     const THUMBNAIL_STANDARD_DEFINITION = 'sddefault';
     const THUMBNAIL_MEDIUM_QUALITY = 'mqdefault';
     const THUMBNAIL_HIGH_QUALITY = 'hqdefault';
     const THUMBNAIL_MAX_QUALITY = 'maxresdefault';
-
 
     /**
      * @param string $url

--- a/src/Container/Factory/ServicesContainerFactory.php
+++ b/src/Container/Factory/ServicesContainerFactory.php
@@ -22,7 +22,7 @@ class ServicesContainerFactory
         return $servicesContainer;
     }
 
-    public static function createNewServiceDetector()
+    public static function createNewServiceMatcher()
     {
         $factory = new self();
 

--- a/src/Exception/ServiceApiNotAvailable.php
+++ b/src/Exception/ServiceApiNotAvailable.php
@@ -2,15 +2,15 @@
 /**
  * Created by PhpStorm.
  * User: Ricardo Fiorani
- * Date: 29/08/2015
- * Time: 20:17
+ * Date: 10/02/2016
+ * Time: 18:13
  */
 
 namespace RicardoFiorani\Exception;
 
 use Exception;
 
-class InvalidThumbnailSizeException extends Exception
+class ServiceApiNotAvailable extends Exception
 {
 
 }

--- a/src/Matcher/VideoServiceMatcher.php
+++ b/src/Matcher/VideoServiceMatcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RicardoFiorani\Detector;
+namespace RicardoFiorani\Matcher;
 
 use RicardoFiorani\Adapter\VideoAdapterInterface;
 use RicardoFiorani\Container\Factory\ServicesContainerFactory;
@@ -10,7 +10,7 @@ use RicardoFiorani\Exception\ServiceNotAvailableException;
 /**
  * @author Ricardo Fiorani
  */
-class VideoServiceDetector
+class VideoServiceMatcher
 {
     /**
      * @var ServicesContainer
@@ -23,11 +23,11 @@ class VideoServiceDetector
     private $parsedUrls = array();
 
     /**
-     * VideoServiceDetector constructor.
+     * VideoServiceMatcher constructor.
      */
     public function __construct()
     {
-        $this->serviceContainer = ServicesContainerFactory::createNewServiceDetector();
+        $this->serviceContainer = ServicesContainerFactory::createNewServiceMatcher();
     }
 
     /**

--- a/test/Adapter/AbstractServiceAdapterTest.php
+++ b/test/Adapter/AbstractServiceAdapterTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Ricardo Fiorani
+ * Date: 10/02/2016
+ * Time: 18:55
+ */
+
+namespace RicardoFiorani\Test\Adapter;
+
+use PHPUnit_Framework_TestCase;
+use RicardoFiorani\Adapter\Facebook\FacebookServiceAdapter;
+use RicardoFiorani\Exception\ServiceNotAvailableException;
+use RicardoFiorani\Matcher\VideoServiceMatcher;
+use RicardoFiorani\Renderer\DefaultRenderer;
+
+class AbstractServiceAdapterTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testGetRawUrl($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $facebookVideo->getRawUrl());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testSetRawUrl($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $testUrl = 'http://test.unit';
+        $facebookVideo->setRawUrl($testUrl);
+        $this->assertEquals($testUrl, $facebookVideo->getRawUrl());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testGetPattern($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $facebookVideo->getPattern());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testSetPattern($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $pattern = '##test.unit##';
+        $facebookVideo->setPattern($pattern);
+        $this->assertEquals($pattern, $facebookVideo->getPattern());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testGetAndSetRenderer($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $renderer = new DefaultRenderer();
+        $facebookVideo->setRenderer($renderer);
+        $this->assertEquals($renderer, $facebookVideo->getRenderer());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testGetEmbedCode($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $embedCode = $facebookVideo->getEmbedCode(1920, 1080);
+        $this->assertInternalType('string', $embedCode);
+        $this->assertContains('1920', $embedCode);
+        $this->assertContains('1080', $embedCode);
+    }
+
+    /**
+     * @return array
+     */
+    public function exampleUrlDataProvider()
+    {
+        return array(
+            array(
+                'https://www.facebook.com/zuck/videos/10102367711349271'
+            ),
+        );
+    }
+
+    /**
+     * @param $url
+     * @return FacebookServiceAdapter
+     * @throws ServiceNotAvailableException
+     */
+    public function getMockingObject($url)
+    {
+        $videoParser = new VideoServiceMatcher();
+        $facebookVideo = $videoParser->parse($url);
+
+        return $facebookVideo;
+    }
+}

--- a/test/Adapter/DailymotionServiceAdapterTest.php
+++ b/test/Adapter/DailymotionServiceAdapterTest.php
@@ -8,11 +8,11 @@
 
 namespace RicardoFiorani\Test\Adapter;
 
-
 use PHPUnit_Framework_TestCase;
 use RicardoFiorani\Adapter\Dailymotion\DailymotionServiceAdapter;
-use RicardoFiorani\Detector\VideoServiceDetector;
+use RicardoFiorani\Matcher\VideoServiceMatcher;
 use RicardoFiorani\Exception\ServiceNotAvailableException;
+
 
 class DailymotionServiceAdapterTest extends PHPUnit_Framework_TestCase
 {
@@ -25,7 +25,6 @@ class DailymotionServiceAdapterTest extends PHPUnit_Framework_TestCase
     {
         $dailymotionVideo = $this->getMockingObject($url);
         $this->assertInternalType('string', $dailymotionVideo->getServiceName());
-
     }
 
     /**
@@ -57,13 +56,10 @@ class DailymotionServiceAdapterTest extends PHPUnit_Framework_TestCase
         $dailymotionVideo = $this->getMockingObject($url);
         $this->assertInternalType('string',
             $dailymotionVideo->getThumbnail(DailymotionServiceAdapter::THUMBNAIL_DEFAULT));
-
         $this->assertInternalType('string', $dailymotionVideo->getSmallThumbnail());
         $this->assertInternalType('string', $dailymotionVideo->getMediumThumbnail());
         $this->assertInternalType('string', $dailymotionVideo->getLargeThumbnail());
         $this->assertInternalType('string', $dailymotionVideo->getLargestThumbnail());
-
-
     }
 
     /**
@@ -75,6 +71,26 @@ class DailymotionServiceAdapterTest extends PHPUnit_Framework_TestCase
         $dailymotionVideo = $this->getMockingObject($url);
         $this->setExpectedException('\\RicardoFiorani\\Exception\\InvalidThumbnailSizeException');
         $dailymotionVideo->getThumbnail('This Size does not exists :)');
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfGetEmbedUrl($url)
+    {
+        $dailymotionVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $dailymotionVideo->getEmbedUrl());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfIsEmbeddable($url)
+    {
+        $dailymotionVideo = $this->getMockingObject($url);
+        $this->assertTrue($dailymotionVideo->isEmbeddable());
     }
 
     /**
@@ -96,7 +112,7 @@ class DailymotionServiceAdapterTest extends PHPUnit_Framework_TestCase
      */
     public function getMockingObject($url)
     {
-        $videoParser = new VideoServiceDetector();
+        $videoParser = new VideoServiceMatcher();
         $dailymotionVideo = $videoParser->parse($url);
 
         return $dailymotionVideo;

--- a/test/Adapter/FacebookServiceAdapterTest.php
+++ b/test/Adapter/FacebookServiceAdapterTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Ricardo Fiorani
+ * Date: 10/02/2016
+ * Time: 15:47
+ */
+
+namespace RicardoFiorani\Test\Adapter;
+
+use PHPUnit_Framework_TestCase;
+use RicardoFiorani\Adapter\Facebook\FacebookServiceAdapter;
+use RicardoFiorani\Matcher\VideoServiceMatcher;
+use RicardoFiorani\Exception\ServiceNotAvailableException;
+
+class FacebookServiceAdapterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testServiceNameIsString($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $facebookVideo->getServiceName());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testHasThumbnailIsBoolean($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->assertInternalType('bool', $facebookVideo->hasThumbnail());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testGetThumbnailSizesIsArray($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->assertInternalType('array', $facebookVideo->getThumbNailSizes());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfGetThumbnailIsString($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string',
+            $facebookVideo->getThumbnail(FacebookServiceAdapter::THUMBNAIL_SIZE_DEFAULT));
+
+        $this->assertInternalType('string', $facebookVideo->getMediumThumbnail());
+
+        $this->assertInternalType('string', $facebookVideo->getLargestThumbnail());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testThrowsExceptionOnRequestThumbnailWithAnInvalidSize($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->setExpectedException('\\RicardoFiorani\\Exception\\InvalidThumbnailSizeException');
+        $facebookVideo->getThumbnail('This Size does not exists :)');
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testGetSmallThumbnailThrowsException($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->setExpectedException('\\RicardoFiorani\\Exception\\ThumbnailSizeNotAvailable');
+        $facebookVideo->getSmallThumbnail();
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testGetLargeThumbnailThrowsException($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->setExpectedException('\\RicardoFiorani\\Exception\\ThumbnailSizeNotAvailable');
+        $facebookVideo->getLargeThumbnail();
+    }
+
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfEmbedUrlIsString($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $facebookVideo->getEmbedUrl());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfIsEmbeddable($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->assertTrue($facebookVideo->isEmbeddable());
+    }
+
+    /**
+     * @return array
+     */
+    public function exampleUrlDataProvider()
+    {
+        return array(
+            array(
+                'https://www.facebook.com/zuck/videos/10102367711349271'
+            ),
+        );
+    }
+
+    /**
+     * @param $url
+     * @return FacebookServiceAdapter
+     * @throws ServiceNotAvailableException
+     */
+    public function getMockingObject($url)
+    {
+        $videoParser = new VideoServiceMatcher();
+        $facebookVideo = $videoParser->parse($url);
+
+        return $facebookVideo;
+    }
+}

--- a/test/Adapter/VimeoServiceAdapterTest.php
+++ b/test/Adapter/VimeoServiceAdapterTest.php
@@ -117,8 +117,8 @@ class VimeoServiceAdapterTest extends PHPUnit_Framework_TestCase
      */
     public function testIfIsEmbeddable($url)
     {
-        $facebookVideo = $this->getMockingObject($url);
-        $this->assertTrue($facebookVideo->isEmbeddable());
+        $vimeoVideo = $this->getMockingObject($url);
+        $this->assertTrue($vimeoVideo->isEmbeddable());
     }
 
     /**
@@ -128,7 +128,8 @@ class VimeoServiceAdapterTest extends PHPUnit_Framework_TestCase
     {
         return array(
             array(
-                'https://vimeo.com/8733915'
+                'https://vimeo.com/8733915',
+                'https://vimeo.com/channels/staffpicks/154766467',
             ),
         );
     }

--- a/test/Adapter/VimeoServiceAdapterTest.php
+++ b/test/Adapter/VimeoServiceAdapterTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Ricardo Fiorani
+ * Date: 10/02/2016
+ * Time: 17:27
+ */
+
+namespace RicardoFiorani\Test\Adapter;
+
+
+use PHPUnit_Framework_TestCase;
+use RicardoFiorani\Adapter\Vimeo\VimeoServiceAdapter;
+use RicardoFiorani\Matcher\VideoServiceMatcher;
+use RicardoFiorani\Exception\ServiceNotAvailableException;
+
+class VimeoServiceAdapterTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testServiceNameIsString($url)
+    {
+        $vimeoVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $vimeoVideo->getServiceName());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testVideoTitleIsString($url)
+    {
+        $vimeoVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $vimeoVideo->getTitle());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testVideoDescriptionIsString($url)
+    {
+        $vimeoVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $vimeoVideo->getDescription());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testHasThumbnailIsBoolean($url)
+    {
+        $vimeoVideo = $this->getMockingObject($url);
+        $this->assertInternalType('bool', $vimeoVideo->hasThumbnail());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testGetThumbnailSizesIsArray($url)
+    {
+        $vimeoVideo = $this->getMockingObject($url);
+        $this->assertInternalType('array', $vimeoVideo->getThumbNailSizes());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfGetThumbnailIsString($url)
+    {
+        $vimeoVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $vimeoVideo->getSmallThumbnail());
+        $this->assertInternalType('string', $vimeoVideo->getMediumThumbnail());
+        $this->assertInternalType('string', $vimeoVideo->getLargeThumbnail());
+        $this->assertInternalType('string', $vimeoVideo->getLargestThumbnail());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfGetThumbnailsIsArray($url)
+    {
+        $vimeoVideo = $this->getMockingObject($url);
+        $this->assertInternalType('array', $vimeoVideo->getThumbnails());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testThrowsExceptionOnRequestThumbnailWithAnInvalidSize($url)
+    {
+        $vimeoVideo = $this->getMockingObject($url);
+        $this->setExpectedException('\\RicardoFiorani\\Exception\\InvalidThumbnailSizeException');
+        $vimeoVideo->getThumbnail('This Size does not exists :)');
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testGetEmbedUrl($url)
+    {
+        $vimeoVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $vimeoVideo->getEmbedUrl());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfIsEmbeddable($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->assertTrue($facebookVideo->isEmbeddable());
+    }
+
+    /**
+     * @return array
+     */
+    public function exampleUrlDataProvider()
+    {
+        return array(
+            array(
+                'https://vimeo.com/8733915'
+            ),
+        );
+    }
+
+    /**
+     * @param $url
+     * @return VimeoServiceAdapter
+     * @throws ServiceNotAvailableException
+     */
+    public function getMockingObject($url)
+    {
+        $videoParser = new VideoServiceMatcher();
+        $vimeoVideo = $videoParser->parse($url);
+
+        return $vimeoVideo;
+    }
+}

--- a/test/Adapter/YoutubeServiceAdapterTest.php
+++ b/test/Adapter/YoutubeServiceAdapterTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Ricardo Fiorani
+ * Date: 10/02/2016
+ * Time: 16:10
+ */
+
+namespace RicardoFiorani\Test\Adapter;
+
+
+use PHPUnit_Framework_TestCase;
+use RicardoFiorani\Adapter\Youtube\YoutubeServiceAdapter;
+use RicardoFiorani\Matcher\VideoServiceMatcher;
+use RicardoFiorani\Exception\ServiceNotAvailableException;
+
+class YoutubeServiceAdapterTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testServiceNameIsString($url)
+    {
+        $youtubeVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $youtubeVideo->getServiceName());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testHasThumbnailIsBoolean($url)
+    {
+        $youtubeVideo = $this->getMockingObject($url);
+        $this->assertInternalType('bool', $youtubeVideo->hasThumbnail());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testGetThumbnailSizesIsArray($url)
+    {
+        $youtubeVideo = $this->getMockingObject($url);
+        $this->assertInternalType('array', $youtubeVideo->getThumbNailSizes());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfGetThumbnailIsString($url)
+    {
+        $youtubeVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $youtubeVideo->getSmallThumbnail());
+        $this->assertInternalType('string', $youtubeVideo->getMediumThumbnail());
+        $this->assertInternalType('string', $youtubeVideo->getLargeThumbnail());
+        $this->assertInternalType('string', $youtubeVideo->getLargestThumbnail());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testThrowsExceptionOnRequestThumbnailWithAnInvalidSize($url)
+    {
+        $youtubeVideo = $this->getMockingObject($url);
+        $this->setExpectedException('\\RicardoFiorani\\Exception\\InvalidThumbnailSizeException');
+        $youtubeVideo->getThumbnail('This Size does not exists :)');
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfEmbedUrlIsString($url)
+    {
+        $youtubeVideo = $this->getMockingObject($url);
+        $this->assertInternalType('string', $youtubeVideo->getEmbedUrl());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfIsEmbeddable($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $this->assertTrue($facebookVideo->isEmbeddable());
+    }
+
+    /**
+     * @return array
+     */
+    public function exampleUrlDataProvider()
+    {
+        return array(
+            array(
+                'https://www.youtube.com/watch?v=uarCDXc3BjU',
+                'https://youtu.be/uarCDXc3BjU',
+                '<iframe width="560" height="315" src="https://www.youtube.com/embed/uarCDXc3BjU" frameborder="0" allowfullscreen></iframe>',
+            ),
+        );
+    }
+
+    /**
+     * @param $url
+     * @return YoutubeServiceAdapter
+     * @throws ServiceNotAvailableException
+     */
+    public function getMockingObject($url)
+    {
+        $videoParser = new VideoServiceMatcher();
+        $youtubeVideo = $videoParser->parse($url);
+
+        return $youtubeVideo;
+    }
+}

--- a/test/Container/ServicesContainerTest.php
+++ b/test/Container/ServicesContainerTest.php
@@ -10,8 +10,79 @@ namespace RicardoFiorani\Test\Container;
 
 
 use PHPUnit_Framework_TestCase;
+use RicardoFiorani\Container\ServicesContainer;
+use stdClass;
 
 class ServicesContainerTest extends PHPUnit_Framework_TestCase
 {
+    public function testServiceContainerServiceRegistrationByArray()
+    {
+        $config = $this->getMockConfig();
+        $serviceContainer = $this->createServiceContainer($config);
+        $this->assertTrue($serviceContainer->hasService('Youtube'));
+        $this->assertInstanceOf('\\RicardoFiorani\\Renderer\\DefaultRenderer', $serviceContainer->getRenderer());
+    }
 
+    public function testServiceContainerServiceRegistrationByInjection()
+    {
+        $serviceContainer = $this->createServiceContainer();
+        $serviceContainer->registerService('TestService', array('#testPattern#'), function () {
+            // @todo test the injected service maybe ?
+        });
+
+        $this->assertContains('TestService', $serviceContainer->getServiceNameList());
+        $this->setExpectedException('\\RicardoFiorani\\Exception\\DuplicatedServiceNameException');
+        $serviceContainer->registerService('TestService', array('#testPattern#'), function () {
+        });
+    }
+
+    public function testServicesList()
+    {
+        $config = $this->getMockConfig();
+        $serviceContainer = $this->createServiceContainer($config);
+        $this->assertInternalType('array', $serviceContainer->getServices());
+        $this->assertContains('Youtube', $serviceContainer->getServices());
+    }
+
+    public function testIfReturnsAlreadyInstantiatedFactory(){
+        $config = $this->getMockConfig();
+        $serviceContainer = $this->createServiceContainer($config);
+        $factory = $serviceContainer->getFactory('Youtube');
+        $this->assertInstanceOf('\\RicardoFiorani\\Adapter\\Youtube\\Factory\\YoutubeServiceAdapterFactory',$factory);
+
+        $alreadyInstantiatedFactory = $serviceContainer->getFactory('Youtube');
+        $this->assertEquals($factory,$alreadyInstantiatedFactory);
+    }
+
+    /**
+     * @return ServicesContainer
+     */
+    private function createServiceContainer(array $constructArray = array())
+    {
+        $serviceContainer = new ServicesContainer($constructArray);
+
+        return $serviceContainer;
+    }
+
+    /**
+     * @return array
+     */
+    private function getMockConfig()
+    {
+        return array(
+            'services' => array(
+                'Youtube' => array(
+                    'patterns' => array(
+                        '#(?:<\>]+href=\")?(?:http://)?((?:[a-zA-Z]{1,4}\.)?youtube.com/(?:watch)?\?v=(.{11}?))[^"]*(?:\"[^\<\>]*>)?([^\<\>]*)(?:)?#',
+                        '%(?:youtube\.com/(?:[^/]+/.+/|(?:v|e(?:mbed)?)/|.*[?&]v=)|youtu\.be/)([^"&?/ ]{11})%i',
+                    ),
+                    'factory' => '\\RicardoFiorani\\Adapter\\Youtube\\Factory\\YoutubeServiceAdapterFactory',
+                ),
+            ),
+            'renderer' => array(
+                'name' => 'DefaultRenderer',
+                'factory' => '\\RicardoFiorani\\Renderer\\Factory\\DefaultRendererFactory',
+            )
+        );
+    }
 }

--- a/test/Container/ServicesContainerTest.php
+++ b/test/Container/ServicesContainerTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Ricardo Fiorani
+ * Date: 10/02/2016
+ * Time: 19:58
+ */
+
+namespace RicardoFiorani\Test\Container;
+
+
+use PHPUnit_Framework_TestCase;
+
+class ServicesContainerTest extends PHPUnit_Framework_TestCase
+{
+
+}

--- a/test/Detector/ServiceDetectorTest.php
+++ b/test/Detector/ServiceDetectorTest.php
@@ -10,7 +10,7 @@ namespace RicardoFiorani\Test\Detector;
 
 use PHPUnit_Framework_TestCase;
 use RicardoFiorani\Container\Factory\ServicesContainerFactory;
-use RicardoFiorani\Detector\VideoServiceDetector;
+use RicardoFiorani\Matcher\VideoServiceMatcher;
 use RicardoFiorani\Exception\ServiceNotAvailableException;
 
 class ServiceDetectorTest extends PHPUnit_Framework_TestCase
@@ -23,7 +23,7 @@ class ServiceDetectorTest extends PHPUnit_Framework_TestCase
      */
     public function testCanParseUrl($url, $expectedServiceName)
     {
-        $detector = new VideoServiceDetector();
+        $detector = new VideoServiceMatcher();
         $video = $detector->parse($url);
         $this->assertInstanceOf($expectedServiceName, $video);
     }
@@ -68,7 +68,7 @@ class ServiceDetectorTest extends PHPUnit_Framework_TestCase
      */
     public function testThrowsExceptionOnInvalidUrl($url)
     {
-        $detector = new VideoServiceDetector();
+        $detector = new VideoServiceMatcher();
         $this->setExpectedException('\\RicardoFiorani\\Exception\\ServiceNotAvailableException');
         $video = $detector->parse($url);
     }
@@ -76,7 +76,7 @@ class ServiceDetectorTest extends PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    public function invalidVideoUrlProvider($url)
+    public function invalidVideoUrlProvider()
     {
         return array(
             array(
@@ -93,28 +93,35 @@ class ServiceDetectorTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider videoUrlProvider
+     * @param $url
+     * @throws ServiceNotAvailableException
      */
     public function testServiceDetectorDontReparseSameUrl($url)
     {
-        $detector = new VideoServiceDetector();
+        $detector = new VideoServiceMatcher();
         $video = $detector->parse($url);
 
         $this->assertSame($video, $detector->parse($url));
     }
 
+    /**
+     * Tests container getter
+     */
     public function testServiceContainerGetter()
     {
-        $detector = new VideoServiceDetector();
+        $detector = new VideoServiceMatcher();
         $this->assertInstanceOf('RicardoFiorani\\Container\\ServicesContainer', $detector->getServiceContainer());
     }
 
+    /**
+     * Tests container setter
+     */
     public function testServiceContainerSetter()
     {
-        $detector = new VideoServiceDetector();
-        $serviceContainer = ServicesContainerFactory::createNewServiceDetector();
+        $detector = new VideoServiceMatcher();
+        $serviceContainer = ServicesContainerFactory::createNewServiceMatcher();
         $detector->setServiceContainer($serviceContainer);
         $this->assertSame($serviceContainer, $detector->getServiceContainer());
     }
-
 
 }

--- a/test/Renderer/DefaultRendererTest.php
+++ b/test/Renderer/DefaultRendererTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Ricardo Fiorani
+ * Date: 10/02/2016
+ * Time: 18:45
+ */
+
+namespace RicardoFiorani\Test\Renderer;
+
+
+use PHPUnit_Framework_TestCase;
+use RicardoFiorani\Renderer\DefaultRenderer;
+
+class DefaultRendererTest extends PHPUnit_Framework_TestCase
+{
+
+    private $embedUrl = 'http://test.unit';
+    private $width = '1920';
+    private $height = '1080';
+
+    public function testIfRenderReturnsString()
+    {
+        $renderer = new DefaultRenderer();
+
+        $output = $renderer->render($this->embedUrl, $this->width, $this->height);
+        $this->assertInternalType('string', $output);
+        $this->assertContains($this->embedUrl, $output);
+        $this->assertContains($this->width, $output);
+        $this->assertContains($this->height, $output);
+    }
+}


### PR DESCRIPTION
# Major changes:
- VideoServiceDetector is now VideoServiceMatcher by naming conventions/design patterns
- Added tests to ensure at least 90% of tested code
- More patterns for Vimeo
- cURL is only required if you want to be able to use Vimeo
# Minor changes:
- Typos fixed
- Removed PHPStorm project file (included mistakenly before)
- Minor Code Optimizations
