### PR TITLE
Make it available to use both http and https schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Coding Standards](https://img.shields.io/badge/cs-PSR--4-yellow.svg)](https://github.com/php-fig-rectified/fig-rectified-standards)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/ricardofiorani/php-video-url-parser/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/ricardofiorani/php-video-url-parser/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/ricardofiorani/php-video-url-parser/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/ricardofiorani/php-video-url-parser/?branch=master)
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/ricardofiorani/php-video-url-parser/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
 PHP Video URL Parser is a parser that detects a given video url and returns an object containing information like the video's embed code, title, description, thumbnail and other information that the service may give.
 
@@ -141,6 +142,4 @@ echo $video->getEmbedCode(500,500);
 * Fix the Exceptions Messages
 * Create PHPUnit Tests
 
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/ricardofiorani/php-video-url-parser/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 

--- a/example/RegisteringANewService.md
+++ b/example/RegisteringANewService.md
@@ -138,7 +138,7 @@ use MyVendor\ServiceAdapter\DailymotionServiceAdapter;
 use RicardoFiorani\Adapter\VideoAdapterInterface;
 use RicardoFiorani\Renderer\EmbedRendererInterface;
 
-class DailymotionServiceAdapterFactory implements \RicardoFiorani\Adapter\Factory\CallableServiceAdapterFactoryInterface
+class DailymotionServiceAdapterFactory implements \RicardoFiorani\Adapter\CallableServiceAdapterFactoryInterface
 {
     /**
      * @param string $url

--- a/src/Adapter/AbstractServiceAdapter.php
+++ b/src/Adapter/AbstractServiceAdapter.php
@@ -35,8 +35,8 @@ abstract class AbstractServiceAdapter implements VideoAdapterInterface
     /**
      * AbstractVideoAdapter constructor.
      *
-     * @param string                 $url
-     * @param string                 $pattern
+     * @param string $url
+     * @param string $pattern
      * @param EmbedRendererInterface $renderer
      */
     public function __construct($url, $pattern, EmbedRendererInterface $renderer)
@@ -113,20 +113,31 @@ abstract class AbstractServiceAdapter implements VideoAdapterInterface
     }
 
     /**
-     * @param int  $width
-     * @param int  $height
+     * @param int $width
+     * @param int $height
      * @param bool $autoplay
      *
      * @return string
      *
      * @throws NotEmbeddableException
      */
-    public function getEmbedCode($width, $height, $autoplay = false)
+    public function getEmbedCode($width, $height, $autoplay = false, $secure = false)
     {
         if (false == $this->isEmbeddable()) {
             throw new NotEmbeddableException();
         }
 
-        return $this->getRenderer()->render($this->getEmbedUrl($autoplay), $width, $height);
+        return $this->getRenderer()->renderVideoEmbedCode($this->getEmbedUrl($autoplay, $secure), $width, $height);
+    }
+
+    /**
+     * Switches the protocol scheme between http and https
+     *
+     * @param bool|false $secure
+     * @return string
+     */
+    public function getScheme($secure = false)
+    {
+        return ($secure ? 'https' : 'http');
     }
 }

--- a/src/Adapter/CallableServiceAdapterFactoryInterface.php
+++ b/src/Adapter/CallableServiceAdapterFactoryInterface.php
@@ -5,7 +5,7 @@
  * Date: 29/08/2015
  * Time: 14:57.
  */
-namespace RicardoFiorani\Adapter\Factory;
+namespace RicardoFiorani\Adapter;
 
 use RicardoFiorani\Adapter\VideoAdapterInterface;
 use RicardoFiorani\Renderer\EmbedRendererInterface;

--- a/src/Adapter/Dailymotion/DailymotionServiceAdapter.php
+++ b/src/Adapter/Dailymotion/DailymotionServiceAdapter.php
@@ -18,8 +18,8 @@ class DailymotionServiceAdapter extends AbstractServiceAdapter
     /**
      * AbstractVideoAdapter constructor.
      *
-     * @param string                 $url
-     * @param string                 $pattern
+     * @param string $url
+     * @param string $pattern
      * @param EmbedRendererInterface $renderer
      */
     public function __construct($url, $pattern, EmbedRendererInterface $renderer)
@@ -64,72 +64,79 @@ class DailymotionServiceAdapter extends AbstractServiceAdapter
 
     /**
      * @param string $size
+     * @param bool $secure
      *
      * @return string
-     *
      * @throws InvalidThumbnailSizeException
      */
-    public function getThumbnail($size)
+    public function getThumbnail($size, $secure = false)
     {
         if (false == in_array($size, $this->getThumbNailSizes())) {
             throw new InvalidThumbnailSizeException();
         }
 
-        return 'http://www.dailymotion.com/'.$size.'/video/'.$this->videoId;
+        return $this->getScheme($secure) . '://www.dailymotion.com/' . $size . '/video/' . $this->videoId;
     }
 
     /**
      * Returns the small thumbnail's url.
      *
+     * @param bool $secure
      * @return string
+     * @throws InvalidThumbnailSizeException
      */
-    public function getSmallThumbnail()
+    public function getSmallThumbnail($secure = false)
     {
         //Since this service does not provide other thumbnails sizes we just return the default size
-        return $this->getThumbnail(self::THUMBNAIL_DEFAULT);
+        return $this->getThumbnail(self::THUMBNAIL_DEFAULT, $secure);
     }
 
     /**
      * Returns the medium thumbnail's url.
      *
+     * @param bool $secure
      * @return string
+     * @throws InvalidThumbnailSizeException
      */
-    public function getMediumThumbnail()
+    public function getMediumThumbnail($secure = false)
     {
         //Since this service does not provide other thumbnails sizes we just return the default size
-        return $this->getThumbnail(self::THUMBNAIL_DEFAULT);
+        return $this->getThumbnail(self::THUMBNAIL_DEFAULT, $secure);
     }
 
     /**
      * Returns the large thumbnail's url.
      *
+     * @param bool $secure
      * @return string
+     * @throws InvalidThumbnailSizeException
      */
-    public function getLargeThumbnail()
+    public function getLargeThumbnail($secure = false)
     {
         //Since this service does not provide other thumbnails sizes we just return the default size
-        return $this->getThumbnail(self::THUMBNAIL_DEFAULT);
+        return $this->getThumbnail(self::THUMBNAIL_DEFAULT, $secure);
     }
 
     /**
      * Returns the largest thumnbnaail's url.
-     *
+     * @param bool $secure
      * @return string
+     * @throws InvalidThumbnailSizeException
      */
-    public function getLargestThumbnail()
+    public function getLargestThumbnail($secure = false)
     {
         //Since this service does not provide other thumbnails sizes we just return the default size
-        return $this->getThumbnail(self::THUMBNAIL_DEFAULT);
+        return $this->getThumbnail(self::THUMBNAIL_DEFAULT, $secure);
     }
 
     /**
      * @param bool $autoplay
-     *
+     * @param bool $secure
      * @return string
      */
-    public function getEmbedUrl($autoplay = false)
+    public function getEmbedUrl($autoplay = false, $secure = false)
     {
-        return '//www.dailymotion.com/embed/video/'.$this->videoId.($autoplay ? '?amp&autoplay=1' : '');
+        return $this->getScheme($secure) . '://www.dailymotion.com/embed/video/' . $this->videoId . ($autoplay ? '?amp&autoplay=1' : '');
     }
 
     /**

--- a/src/Adapter/Dailymotion/Factory/DailymotionServiceAdapterFactory.php
+++ b/src/Adapter/Dailymotion/Factory/DailymotionServiceAdapterFactory.php
@@ -8,7 +8,7 @@
 namespace RicardoFiorani\Adapter\Dailymotion\Factory;
 
 use RicardoFiorani\Adapter\Dailymotion\DailymotionServiceAdapter;
-use RicardoFiorani\Adapter\Factory\CallableServiceAdapterFactoryInterface;
+use RicardoFiorani\Adapter\CallableServiceAdapterFactoryInterface;
 use RicardoFiorani\Adapter\VideoAdapterInterface;
 use RicardoFiorani\Renderer\EmbedRendererInterface;
 

--- a/src/Adapter/Facebook/FacebookServiceAdapter.php
+++ b/src/Adapter/Facebook/FacebookServiceAdapter.php
@@ -19,8 +19,8 @@ class FacebookServiceAdapter extends AbstractServiceAdapter
     /**
      * AbstractVideoAdapter constructor.
      *
-     * @param string                 $url
-     * @param string                 $pattern
+     * @param string $url
+     * @param string $pattern
      * @param EmbedRendererInterface $renderer
      */
     public function __construct($url, $pattern, EmbedRendererInterface $renderer)
@@ -33,7 +33,7 @@ class FacebookServiceAdapter extends AbstractServiceAdapter
     }
 
     /**
-     * Returns the service name (ie: "Youtube" or "Vimeo").
+     * Returns the service name .
      *
      * @return string
      */
@@ -65,27 +65,27 @@ class FacebookServiceAdapter extends AbstractServiceAdapter
     /**
      * @param string $size
      *
+     * @param bool $secure
      * @return string
-     *
      * @throws InvalidThumbnailSizeException
      */
-    public function getThumbnail($size)
+    public function getThumbnail($size, $secure = false)
     {
         if (false == in_array($size, $this->getThumbNailSizes())) {
             throw new InvalidThumbnailSizeException();
         }
 
-        return 'https://graph.facebook.com/'.$this->getVideoId().'/picture';
+        return $this->getScheme($secure) . '://graph.facebook.com/' . $this->getVideoId() . '/picture';
     }
 
     /**
      * Returns the small thumbnail's url.
      *
+     * @param bool $secure
      * @return string
-     *
      * @throws ThumbnailSizeNotAvailable
      */
-    public function getSmallThumbnail()
+    public function getSmallThumbnail($secure = false)
     {
         throw new ThumbnailSizeNotAvailable();
     }
@@ -93,43 +93,48 @@ class FacebookServiceAdapter extends AbstractServiceAdapter
     /**
      * Returns the medium thumbnail's url.
      *
+     * @param bool $secure
      * @return string
+     * @throws InvalidThumbnailSizeException
      */
-    public function getMediumThumbnail()
+    public function getMediumThumbnail($secure = false)
     {
-        return $this->getThumbnail(self::THUMBNAIL_SIZE_DEFAULT);
+        return $this->getThumbnail(self::THUMBNAIL_SIZE_DEFAULT, $secure);
     }
 
     /**
      * Returns the large thumbnail's url.
      *
+     * @param bool $secure
      * @return string
-     *
      * @throws ThumbnailSizeNotAvailable
      */
-    public function getLargeThumbnail()
+    public function getLargeThumbnail($secure = false)
     {
         throw new ThumbnailSizeNotAvailable();
     }
 
     /**
-     * Returns the largest thumnbnaail's url.
+     * Returns the largest thumbnail's url.
      *
+     * @param bool $secure
      * @return string
+     * @throws InvalidThumbnailSizeException
      */
-    public function getLargestThumbnail()
+    public function getLargestThumbnail($secure = false)
     {
-        return $this->getThumbnail(self::THUMBNAIL_SIZE_DEFAULT);
+        return $this->getThumbnail(self::THUMBNAIL_SIZE_DEFAULT, $secure);
     }
 
     /**
      * @param bool $autoplay
      *
+     * @param bool $secure
      * @return string
      */
-    public function getEmbedUrl($autoplay = false)
+    public function getEmbedUrl($autoplay = false, $secure = false)
     {
-        return 'https://www.facebook.com/video/embed?video_id='.$this->getVideoId();
+        return $this->getScheme($secure) . '://www.facebook.com/video/embed?video_id=' . $this->getVideoId();
     }
 
     /**

--- a/src/Adapter/Facebook/Factory/FacebookServiceAdapterFactory.php
+++ b/src/Adapter/Facebook/Factory/FacebookServiceAdapterFactory.php
@@ -8,7 +8,7 @@
 namespace RicardoFiorani\Adapter\Facebook\Factory;
 
 use RicardoFiorani\Adapter\Facebook\FacebookServiceAdapter;
-use RicardoFiorani\Adapter\Factory\CallableServiceAdapterFactoryInterface;
+use RicardoFiorani\Adapter\CallableServiceAdapterFactoryInterface;
 use RicardoFiorani\Adapter\VideoAdapterInterface;
 use RicardoFiorani\Renderer\EmbedRendererInterface;
 

--- a/src/Adapter/VideoAdapterInterface.php
+++ b/src/Adapter/VideoAdapterInterface.php
@@ -47,46 +47,52 @@ interface VideoAdapterInterface
     /**
      * Returns the small thumbnail's url.
      *
+     * @param bool $secure
      * @return string
      */
-    public function getSmallThumbnail();
+    public function getSmallThumbnail($secure = false);
 
     /**
      * Returns the medium thumbnail's url.
      *
+     * @param bool $secure
      * @return string
      */
-    public function getMediumThumbnail();
+    public function getMediumThumbnail($secure = false);
 
     /**
      * Returns the large thumbnail's url.
      *
+     * @param bool $secure
      * @return string
      */
-    public function getLargeThumbnail();
+    public function getLargeThumbnail($secure = false);
 
     /**
      * Returns the largest thumnbnail's url.
      *
+     * @param bool $secure
      * @return string
      */
-    public function getLargestThumbnail();
+    public function getLargestThumbnail($secure = false);
 
     /**
      * @param bool $autoplay
+     * @param bool $secure
      *
      * @return string
      */
-    public function getEmbedUrl($autoplay = false);
+    public function getEmbedUrl($autoplay = false, $secure = false);
 
     /**
-     * @param int  $width
-     * @param int  $height
+     * @param int $width
+     * @param int $height
      * @param bool $autoplay
+     * @param bool $secure
      *
      * @return string
      */
-    public function getEmbedCode($width, $height, $autoplay = false);
+    public function getEmbedCode($width, $height, $autoplay = false, $secure = false);
 
     /**
      * @return bool

--- a/src/Adapter/Vimeo/Factory/VimeoServiceAdapterFactory.php
+++ b/src/Adapter/Vimeo/Factory/VimeoServiceAdapterFactory.php
@@ -7,7 +7,7 @@
  */
 namespace RicardoFiorani\Adapter\Vimeo\Factory;
 
-use RicardoFiorani\Adapter\Factory\CallableServiceAdapterFactoryInterface;
+use RicardoFiorani\Adapter\CallableServiceAdapterFactoryInterface;
 use RicardoFiorani\Adapter\Vimeo\VimeoServiceAdapter;
 use RicardoFiorani\Renderer\EmbedRendererInterface;
 

--- a/src/Adapter/Vimeo/VimeoServiceAdapter.php
+++ b/src/Adapter/Vimeo/VimeoServiceAdapter.php
@@ -34,8 +34,8 @@ class VimeoServiceAdapter extends AbstractServiceAdapter
     public $thumbnails;
 
     /**
-     * @param string                 $url
-     * @param string                 $pattern
+     * @param string $url
+     * @param string $pattern
      * @param EmbedRendererInterface $renderer
      */
     public function __construct($url, $pattern, EmbedRendererInterface $renderer)
@@ -109,19 +109,13 @@ class VimeoServiceAdapter extends AbstractServiceAdapter
     }
 
     /**
-     * @return array
-     */
-    public function getThumbnails()
-    {
-        return $this->thumbnails;
-    }
-
-    /**
      * @param array $thumbnails
      */
-    public function setThumbnails($thumbnails)
+    private function setThumbnails(array $thumbnails)
     {
-        $this->thumbnails = $thumbnails;
+        foreach ($thumbnails as $key => $thumbnail) {
+            $this->thumbnails[$key] = parse_url($thumbnail);
+        }
     }
 
     /**
@@ -131,13 +125,13 @@ class VimeoServiceAdapter extends AbstractServiceAdapter
      *
      * @throws InvalidThumbnailSizeException
      */
-    public function getThumbnail($size)
+    public function getThumbnail($size, $secure = false)
     {
         if (false == in_array($size, $this->getThumbNailSizes())) {
             throw new InvalidThumbnailSizeException();
         }
 
-        return $this->thumbnails[$size];
+        return $this->getScheme($secure) . '://' . $this->thumbnails[$size]['host'] . $this->thumbnails[$size]['path'];
     }
 
     /**
@@ -145,9 +139,9 @@ class VimeoServiceAdapter extends AbstractServiceAdapter
      *
      * @return string
      */
-    public function getEmbedUrl($autoplay = false)
+    public function getEmbedUrl($autoplay = false, $secure = false)
     {
-        return 'http://player.vimeo.com/video/'.$this->getVideoId().($autoplay ? '?autoplay=1' : '');
+        return $this->getScheme($secure) . '://player.vimeo.com/video/' . $this->getVideoId() . ($autoplay ? '?autoplay=1' : '');
     }
 
     /**
@@ -167,41 +161,51 @@ class VimeoServiceAdapter extends AbstractServiceAdapter
     /**
      * Returns the small thumbnail's url.
      *
+     * @param bool $secure
      * @return string
+     * @throws InvalidThumbnailSizeException
      */
-    public function getSmallThumbnail()
+    public function getSmallThumbnail($secure = false)
     {
-        return $this->getThumbnail(self::THUMBNAIL_SMALL);
+        return $this->getThumbnail(self::THUMBNAIL_SMALL,$secure);
     }
 
     /**
      * Returns the medium thumbnail's url.
      *
+     * @param bool $secure
      * @return string
+     * @throws InvalidThumbnailSizeException
      */
-    public function getMediumThumbnail()
+    public function getMediumThumbnail($secure = false)
     {
-        return $this->getThumbnail(self::THUMBNAIL_MEDIUM);
+        return $this->getThumbnail(self::THUMBNAIL_MEDIUM,$secure);
     }
 
     /**
      * Returns the large thumbnail's url.
      *
+     * @param bool $secure
+     * @param $secure
      * @return string
+     * @throws InvalidThumbnailSizeException
      */
-    public function getLargeThumbnail()
+    public function getLargeThumbnail($secure = false)
     {
-        return $this->getThumbnail(self::THUMBNAIL_LARGE);
+        return $this->getThumbnail(self::THUMBNAIL_LARGE,$secure);
     }
 
     /**
      * Returns the largest thumnbnaail's url.
      *
+     * @param bool $secure
+     * @param $secure
      * @return string
+     * @throws InvalidThumbnailSizeException
      */
-    public function getLargestThumbnail()
+    public function getLargestThumbnail($secure = false)
     {
-        return $this->getThumbnail(self::THUMBNAIL_LARGE);
+        return $this->getThumbnail(self::THUMBNAIL_LARGE,$secure);
     }
 
     /**
@@ -238,7 +242,7 @@ class VimeoServiceAdapter extends AbstractServiceAdapter
      */
     private function getVideoDataFromServiceApi()
     {
-        $contents = file_get_contents('http://vimeo.com/api/v2/video/'.$this->getVideoId().'.php');
+        $contents = file_get_contents('http://vimeo.com/api/v2/video/' . $this->getVideoId() . '.php');
         if (false === $contents) {
             throw new ServiceApiNotAvailable('Vimeo Service Adapter could not reach Vimeo API Service. Check if your server has file_get_contents() function available.');
         }

--- a/src/Adapter/Youtube/Factory/YoutubeServiceAdapterFactory.php
+++ b/src/Adapter/Youtube/Factory/YoutubeServiceAdapterFactory.php
@@ -7,7 +7,7 @@
  */
 namespace RicardoFiorani\Adapter\Youtube\Factory;
 
-use RicardoFiorani\Adapter\Factory\CallableServiceAdapterFactoryInterface;
+use RicardoFiorani\Adapter\CallableServiceAdapterFactoryInterface;
 use RicardoFiorani\Adapter\Youtube\YoutubeServiceAdapter;
 use RicardoFiorani\Renderer\EmbedRendererInterface;
 

--- a/src/Adapter/Youtube/YoutubeServiceAdapter.php
+++ b/src/Adapter/Youtube/YoutubeServiceAdapter.php
@@ -20,8 +20,8 @@ class YoutubeServiceAdapter extends AbstractServiceAdapter
     const THUMBNAIL_MAX_QUALITY = 'maxresdefault';
 
     /**
-     * @param string                 $url
-     * @param string                 $pattern
+     * @param string $url
+     * @param string $pattern
      * @param EmbedRendererInterface $renderer
      */
     public function __construct($url, $pattern, EmbedRendererInterface $renderer)
@@ -60,18 +60,17 @@ class YoutubeServiceAdapter extends AbstractServiceAdapter
 
     /**
      * @param string $size
-     *
+     * @param bool $secure
      * @return string
-     *
      * @throws InvalidThumbnailSizeException
      */
-    public function getThumbnail($size)
+    public function getThumbnail($size, $secure = false)
     {
         if (false == in_array($size, $this->getThumbNailSizes())) {
             throw new InvalidThumbnailSizeException();
         }
 
-        return 'http://img.youtube.com/vi/'.$this->getVideoId().'/'.$size.'.jpg';
+        return $this->getScheme($secure) . '://img.youtube.com/vi/' . $this->getVideoId() . '/' . $size . '.jpg';
     }
 
     /**
@@ -90,12 +89,12 @@ class YoutubeServiceAdapter extends AbstractServiceAdapter
 
     /**
      * @param bool $autoplay
-     *
+     * @param bool $secure
      * @return string
      */
-    public function getEmbedUrl($autoplay = false)
+    public function getEmbedUrl($autoplay = false, $secure = false)
     {
-        return 'http://www.youtube.com/embed/'.$this->getVideoId().($autoplay ? '?amp&autoplay=1' : '');
+        return $this->getScheme($secure) . '://www.youtube.com/embed/' . $this->getVideoId() . ($autoplay ? '?amp&autoplay=1' : '');
     }
 
     /**
@@ -103,9 +102,9 @@ class YoutubeServiceAdapter extends AbstractServiceAdapter
      *
      * @return string
      */
-    public function getSmallThumbnail()
+    public function getSmallThumbnail($secure = false)
     {
-        return $this->getThumbnail(self::THUMBNAIL_STANDARD_DEFINITION);
+        return $this->getThumbnail(self::THUMBNAIL_STANDARD_DEFINITION, $secure);
     }
 
     /**
@@ -113,9 +112,9 @@ class YoutubeServiceAdapter extends AbstractServiceAdapter
      *
      * @return string
      */
-    public function getMediumThumbnail()
+    public function getMediumThumbnail($secure = false)
     {
-        return $this->getThumbnail(self::THUMBNAIL_MEDIUM_QUALITY);
+        return $this->getThumbnail(self::THUMBNAIL_MEDIUM_QUALITY, $secure);
     }
 
     /**
@@ -123,9 +122,9 @@ class YoutubeServiceAdapter extends AbstractServiceAdapter
      *
      * @return string
      */
-    public function getLargeThumbnail()
+    public function getLargeThumbnail($secure = false)
     {
-        return $this->getThumbnail(self::THUMBNAIL_HIGH_QUALITY);
+        return $this->getThumbnail(self::THUMBNAIL_HIGH_QUALITY, $secure);
     }
 
     /**
@@ -133,9 +132,9 @@ class YoutubeServiceAdapter extends AbstractServiceAdapter
      *
      * @return string
      */
-    public function getLargestThumbnail()
+    public function getLargestThumbnail($secure = false)
     {
-        return $this->getThumbnail(self::THUMBNAIL_MAX_QUALITY);
+        return $this->getThumbnail(self::THUMBNAIL_MAX_QUALITY, $secure);
     }
 
     /**

--- a/src/Container/ServicesContainer.php
+++ b/src/Container/ServicesContainer.php
@@ -7,7 +7,7 @@
  */
 namespace RicardoFiorani\Container;
 
-use RicardoFiorani\Adapter\Factory\CallableServiceAdapterFactoryInterface;
+use RicardoFiorani\Adapter\CallableServiceAdapterFactoryInterface;
 use RicardoFiorani\Exception\DuplicatedServiceNameException;
 use RicardoFiorani\Renderer\EmbedRendererInterface;
 
@@ -144,17 +144,17 @@ class ServicesContainer
     }
 
     /**
-     * @param string $service
+     * @param string $serviceName
      *
      * @return CallableServiceAdapterFactoryInterface
      */
-    public function getFactory($service)
+    public function getFactory($serviceName)
     {
-        $factory = new $this->factories[$service]();
-        if (isset($this->instantiatedFactories[$service])) {
-            return $this->instantiatedFactories[$service];
+        $factory = new $this->factories[$serviceName]();
+        if (isset($this->instantiatedFactories[$serviceName])) {
+            return $this->instantiatedFactories[$serviceName];
         }
 
-        return $this->instantiatedFactories[$service] = $factory;
+        return $this->instantiatedFactories[$serviceName] = $factory;
     }
 }

--- a/src/Renderer/DefaultRenderer.php
+++ b/src/Renderer/DefaultRenderer.php
@@ -23,7 +23,7 @@ class DefaultRenderer implements EmbedRendererInterface
      *
      * @return string
      */
-    public function render($embedUrl, $width, $height)
+    public function renderVideoEmbedCode($embedUrl, $width, $height)
     {
         return '<iframe width="'.$width.'" height="'.$height.'" src="'.addslashes($embedUrl).'" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>';
     }

--- a/src/Renderer/EmbedRendererInterface.php
+++ b/src/Renderer/EmbedRendererInterface.php
@@ -16,5 +16,5 @@ interface EmbedRendererInterface
      *
      * @return string
      */
-    public function render($embedUrl, $width, $height);
+    public function renderVideoEmbedCode($embedUrl, $width, $height);
 }

--- a/test/Adapter/AbstractServiceAdapterTest.php
+++ b/test/Adapter/AbstractServiceAdapterTest.php
@@ -87,6 +87,19 @@ class AbstractServiceAdapterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider exampleUrlDataProvider
+     * @param $url
+     */
+    public function testGetScheme($url)
+    {
+        $facebookVideo = $this->getMockingObject($url);
+        $schemeInsecure = $facebookVideo->getScheme(false);
+        $this->assertEquals('http', $schemeInsecure);
+        $schemeSecure = $facebookVideo->getScheme(true);
+        $this->assertEquals('https', $schemeSecure);
+    }
+
+    /**
      * @return array
      */
     public function exampleUrlDataProvider()

--- a/test/Adapter/DailymotionServiceAdapterTest.php
+++ b/test/Adapter/DailymotionServiceAdapterTest.php
@@ -87,6 +87,20 @@ class DailymotionServiceAdapterTest extends PHPUnit_Framework_TestCase
      * @dataProvider exampleUrlDataProvider
      * @param string $url
      */
+    public function testIfGetEmbedUrlUsesRightScheme($url)
+    {
+        $videoObject = $this->getMockingObject($url);
+        $embedUrl = $videoObject->getEmbedUrl(false, true);
+        $this->assertContains('https', $embedUrl);
+
+        $embedUrl = $videoObject->getEmbedUrl(false, false);
+        $this->assertNotContains('https', $embedUrl);
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
     public function testIfIsEmbeddable($url)
     {
         $dailymotionVideo = $this->getMockingObject($url);

--- a/test/Adapter/FacebookServiceAdapterTest.php
+++ b/test/Adapter/FacebookServiceAdapterTest.php
@@ -108,6 +108,20 @@ class FacebookServiceAdapterTest extends PHPUnit_Framework_TestCase
      * @dataProvider exampleUrlDataProvider
      * @param string $url
      */
+    public function testIfGetEmbedUrlUsesRightScheme($url)
+    {
+        $videoObject = $this->getMockingObject($url);
+        $embedUrl = $videoObject->getEmbedUrl(false, true);
+        $this->assertContains('https', $embedUrl);
+
+        $embedUrl = $videoObject->getEmbedUrl(false, false);
+        $this->assertNotContains('https', $embedUrl);
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
     public function testIfIsEmbeddable($url)
     {
         $facebookVideo = $this->getMockingObject($url);

--- a/test/Adapter/VimeoServiceAdapterTest.php
+++ b/test/Adapter/VimeoServiceAdapterTest.php
@@ -84,16 +84,6 @@ class VimeoServiceAdapterTest extends PHPUnit_Framework_TestCase
      * @dataProvider exampleUrlDataProvider
      * @param string $url
      */
-    public function testIfGetThumbnailsIsArray($url)
-    {
-        $vimeoVideo = $this->getMockingObject($url);
-        $this->assertInternalType('array', $vimeoVideo->getThumbnails());
-    }
-
-    /**
-     * @dataProvider exampleUrlDataProvider
-     * @param string $url
-     */
     public function testThrowsExceptionOnRequestThumbnailWithAnInvalidSize($url)
     {
         $vimeoVideo = $this->getMockingObject($url);
@@ -109,6 +99,20 @@ class VimeoServiceAdapterTest extends PHPUnit_Framework_TestCase
     {
         $vimeoVideo = $this->getMockingObject($url);
         $this->assertInternalType('string', $vimeoVideo->getEmbedUrl());
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
+    public function testIfGetEmbedUrlUsesRightScheme($url)
+    {
+        $videoObject = $this->getMockingObject($url);
+        $embedUrl = $videoObject->getEmbedUrl(false, true);
+        $this->assertContains('https', $embedUrl);
+
+        $embedUrl = $videoObject->getEmbedUrl(false, false);
+        $this->assertNotContains('https', $embedUrl);
     }
 
     /**

--- a/test/Adapter/YoutubeServiceAdapterTest.php
+++ b/test/Adapter/YoutubeServiceAdapterTest.php
@@ -85,6 +85,20 @@ class YoutubeServiceAdapterTest extends PHPUnit_Framework_TestCase
      * @dataProvider exampleUrlDataProvider
      * @param string $url
      */
+    public function testIfGetEmbedUrlUsesRightScheme($url)
+    {
+        $videoObject = $this->getMockingObject($url);
+        $embedUrl = $videoObject->getEmbedUrl(false, true);
+        $this->assertContains('https', $embedUrl);
+
+        $embedUrl = $videoObject->getEmbedUrl(false, false);
+        $this->assertNotContains('https', $embedUrl);
+    }
+
+    /**
+     * @dataProvider exampleUrlDataProvider
+     * @param string $url
+     */
     public function testIfIsEmbeddable($url)
     {
         $facebookVideo = $this->getMockingObject($url);

--- a/test/Detector/VideoServiceMatcherTest.php
+++ b/test/Detector/VideoServiceMatcherTest.php
@@ -13,7 +13,7 @@ use RicardoFiorani\Container\Factory\ServicesContainerFactory;
 use RicardoFiorani\Matcher\VideoServiceMatcher;
 use RicardoFiorani\Exception\ServiceNotAvailableException;
 
-class ServiceDetectorTest extends PHPUnit_Framework_TestCase
+class VideoServiceMatcherTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider videoUrlProvider

--- a/test/Renderer/DefaultRendererTest.php
+++ b/test/Renderer/DefaultRendererTest.php
@@ -23,7 +23,7 @@ class DefaultRendererTest extends PHPUnit_Framework_TestCase
     {
         $renderer = new DefaultRenderer();
 
-        $output = $renderer->render($this->embedUrl, $this->width, $this->height);
+        $output = $renderer->renderVideoEmbedCode($this->embedUrl, $this->width, $this->height);
         $this->assertInternalType('string', $output);
         $this->assertContains($this->embedUrl, $output);
         $this->assertContains($this->width, $output);


### PR DESCRIPTION
This PR intends to make it available to specify which scheme will be used in both video embed URL and video thumbnail's URL.

Minor changes:
- Update on README.MD
- Refactored CallableServiceAdapterFactoryInterface's namespace

This PR fixes issue #4 
