### PR TITLE
Add PSR-16 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
         }
     ],
     "require": {
-        "php": ">=7.1"
+        "php": ">=7.1",
+        "psr/simple-cache": "^1.0",
+        "roave/doctrine-simplecache": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Matcher/VideoServiceMatcher.php
+++ b/src/Matcher/VideoServiceMatcher.php
@@ -33,7 +33,7 @@ class VideoServiceMatcher
     public function parse($url): VideoAdapterInterface
     {
         $url = (string) $url;
-        $cacheKey = hash('sha256',  $url);
+        $cacheKey = (string) crc32($url);
         if ($this->cache->has($cacheKey)) {
             return $this->cache->get($cacheKey);
         }

--- a/src/Matcher/VideoServiceMatcher.php
+++ b/src/Matcher/VideoServiceMatcher.php
@@ -33,7 +33,7 @@ class VideoServiceMatcher
     public function parse($url): VideoAdapterInterface
     {
         $url = (string) $url;
-        $cacheKey = (string) crc32($url);
+        $cacheKey = hash('md5', $url);
         if ($this->cache->has($cacheKey)) {
             return $this->cache->get($cacheKey);
         }


### PR DESCRIPTION
Proposal to close #10 

Note: The `roave/doctrine-simplecache` + `doctrine/cache` was the minimal dependency setup I found that do **not** serialize the data when saving it, therefore `VideoServiceMatcherTest::testServiceDetectorDontReparseSameUrl()` is still green. For reference, both [PSR-16](https://www.php-fig.org/psr/psr-16/#14-data) and [PSR-6](https://www.php-fig.org/psr/psr-6/#data) has this statement :

> Implementing Libraries MAY use PHP’s serialize()/unserialize() functions internally but are not required to do so.